### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jenspapenhagen/color-picker/security/code-scanning/1](https://github.com/jenspapenhagen/color-picker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal necessary permissions. Based on the workflow's content, which primarily involves checking out code and building a Java project with Maven, it requires only read access to the repository contents. Therefore, we will set `permissions: contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
